### PR TITLE
Add markdown output

### DIFF
--- a/src/main/kotlin/com/asarkar/gradle/buildtimetracker/BuildTimeTrackerPluginExtension.kt
+++ b/src/main/kotlin/com/asarkar/gradle/buildtimetracker/BuildTimeTrackerPluginExtension.kt
@@ -11,7 +11,7 @@ enum class BarPosition {
 }
 
 enum class Output {
-    CONSOLE, CSV
+    CONSOLE, CSV, MARKDOWN
 }
 
 enum class Sort {

--- a/src/main/kotlin/com/asarkar/gradle/buildtimetracker/Constants.kt
+++ b/src/main/kotlin/com/asarkar/gradle/buildtimetracker/Constants.kt
@@ -9,4 +9,5 @@ object Constants {
     const val DEFAULT_MIN_TASK_DURATION = 1L
     const val DEFAULT_SHOW_BARS = true
     const val CSV_FILENAME = "build.csv"
+    const val MARKDOWN_FILENAME = "build.md"
 }

--- a/src/main/kotlin/com/asarkar/gradle/buildtimetracker/Printer.kt
+++ b/src/main/kotlin/com/asarkar/gradle/buildtimetracker/Printer.kt
@@ -46,17 +46,19 @@ interface Printer : Closeable {
             )
 
             if (!input.showBars) {
-                out.println(common)
+                out.printf("%s%s%s\n", prefix(), common, suffix())
             } else if (input.barPosition == BarPosition.TRAILING) {
-                out.printf("%s%s%s\n", common, delimiter, "$BLOCK_CHAR".repeat(numBlocks))
+                out.printf("%s%s%s%s%s\n", prefix(), common, delimiter, "$BLOCK_CHAR".repeat(numBlocks), suffix())
             } else {
-                out.printf("%${maxNumBlocks}s%s%s\n", "$BLOCK_CHAR".repeat(numBlocks), delimiter, common)
+                out.printf("%s%${maxNumBlocks}s%s%s%s\n", prefix(), "$BLOCK_CHAR".repeat(numBlocks), delimiter, common, suffix())
             }
         }
     }
 
     val out: PrintStream
     val delimiter: String
+    fun prefix(): String = ""
+    fun suffix(): String = ""
 
     companion object {
         const val BLOCK_CHAR = '\u2588'
@@ -77,6 +79,11 @@ interface Printer : Closeable {
                     val csvFile = reportsDir
                         .resolve(Constants.CSV_FILENAME)
                     CsvPrinter(newOutputStream(csvFile))
+                }
+                Output.MARKDOWN -> {
+                    val markdownFile = reportsDir
+                        .resolve(Constants.MARKDOWN_FILENAME)
+                    MarkdownPrinter(newOutputStream(markdownFile))
                 }
             }
         }

--- a/src/main/kotlin/com/asarkar/gradle/buildtimetracker/Printers.kt
+++ b/src/main/kotlin/com/asarkar/gradle/buildtimetracker/Printers.kt
@@ -24,3 +24,31 @@ class CsvPrinter(
         out.close()
     }
 }
+
+class MarkdownPrinter(
+    override val out: PrintStream,
+    override val delimiter: String = " | "
+) : Printer {
+
+    override fun prefix(): String = "| "
+    override fun suffix(): String = " |"
+
+    override fun print(input: PrinterInput) {
+        out.println("# Build time summary")
+        if (!input.showBars) {
+            out.println("| Task name | Time | Percentage |")
+            out.println("|:----------|-----:|-----------:|")
+        } else if (input.barPosition == BarPosition.TRAILING) {
+            out.println("| Task name | Time | Percentage | Bar |")
+            out.println("|:----------|-----:|-----------:|----:|")
+        } else {
+            out.println("| Bar | Task name | Time | Percentage |")
+            out.println("|----:|:----------|-----:|-----------:|")
+        }
+        super.print(input)
+    }
+
+    override fun close() {
+        // Do nothing
+    }
+}


### PR DESCRIPTION
This adds support to output the values as Markdown. The output would be such as:

## Trailing bar

```markdown
# Build time summary

| Task name | Time | Percentage | Bar |
|:----------|-----:|-----------:|----:|
|  :commons:extractIncludeProto | 4S | 14% | ████ |
|        :commons:compileKotlin | 2S |  7% | ██ |
|          :commons:compileJava | 6S | 21% | ██████ |
| :service-client:compileKotlin | 1S |  4% | █ |
|         :webapp:compileKotlin | 1S |  4% | █ |
|      :webapp:dockerBuildImage | 4S | 14% | ████ |
|       :webapp:dockerPushImage | 4S | 14% | ████ |
```

## Leading bar

```markdown
# Build time summary

| Bar | Task name | Time | Percentage |
|----:|:----------|-----:|-----------:|
|             █ | :service-client:compileKotlin |  1S |  4% |
| █████████████ |                   webapp:test | 13S | 46% |
```

## No bar


```markdown
# Build time summary

| Task name | Time | Percentage |
|:----------|-----:|-----------:|
|  :commons:extractIncludeProto | 4S | 14% |
|        :commons:compileKotlin | 2S |  7% |
|          :commons:compileJava | 6S | 21% |
| :service-client:compileKotlin | 1S |  4% |
|         :webapp:compileKotlin | 1S |  4% |
|      :webapp:dockerBuildImage | 4S | 14% |
|       :webapp:dockerPushImage | 4S | 14% |
```

(examples extracted from tests execution)

The tables do not need to be perfectly formatted to render correctly. For example, the last table renders here as:

# Build time summary

| Task name | Time | Percentage |
|:----------|-----:|-----------:|
|  :commons:extractIncludeProto | 4S | 14% |
|        :commons:compileKotlin | 2S |  7% |
|          :commons:compileJava | 6S | 21% |
| :service-client:compileKotlin | 1S |  4% |
|         :webapp:compileKotlin | 1S |  4% |
|      :webapp:dockerBuildImage | 4S | 14% |
|       :webapp:dockerPushImage | 4S | 14% |

:-)